### PR TITLE
Automatically redraw after events

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,9 +61,6 @@ const ComponentToTest = {
           {
             onDocumentClick: () => {
               vnode.state.showList = false;
-              // since this click handler is outside mithril ecosystem, we 
-              // have to force redraw
-              m.redraw();
             },
           },
           m("ul", { "data-testid": "the-list" }, [(m("li", 1), m("li", 2))])

--- a/src/mithril-testing-library.js
+++ b/src/mithril-testing-library.js
@@ -1,5 +1,24 @@
 import m from "mithril";
-import { getQueriesForElement, prettyDOM } from "@testing-library/dom";
+import { getQueriesForElement, prettyDOM, configure} from "@testing-library/dom";
+
+/**
+ * This avoid the need to add redraw to the callbacks or manually call
+ * m.redraw.sync() from within the tests.
+ */
+configure({
+  eventWrapper: (cb) => {
+    const result = cb();
+    m.redraw.sync();
+    return result;
+  },
+  asyncWrapper: (cb) => {
+    const result = cb();
+    m.redraw.sync();
+    return result;
+  }
+});
+
+
 
 const mountedContainers = new Set();
 /*


### PR DESCRIPTION
This PR removes the need to manually call redraw after events by using the eventWrapper and asyncWrapper configuration properties of testing-library.
 
